### PR TITLE
Update ExampleApp to use the bugfix version 1.5.1 of the CIQ Companion app SDK

### DIFF
--- a/ExampleApp/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ExampleApp/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/garmin/connectiq-companion-app-sdk-ios",
       "state" : {
-        "revision" : "fc5021539b4fce26334b2609d7076c25c08c1b04",
-        "version" : "1.5.0"
+        "revision" : "8c5ac2a04b95d07df2c57ceec46a6d97a5605120",
+        "version" : "1.5.1"
       }
     }
   ],


### PR DESCRIPTION
Updated the ExampleApp to use the bugfix version 1.5.1 of the CIQ Companion app SDK which addresses the issue of the app not able to detect the corresponding Monkeybrains app installed on the device.