### PR TITLE
Fix issue with loading paired devices for device selection.

### DIFF
--- a/ExampleApp/ExampleApp/AppDelegate.m
+++ b/ExampleApp/ExampleApp/AppDelegate.m
@@ -60,7 +60,7 @@
     NSString* sourceApp = options[UIApplicationOpenURLOptionsSourceApplicationKey];
     NSLog(@"Received URL from '%@': %@", sourceApp, url);
 
-    return [[DeviceManager sharedManager] handleOpenURL:url sourceApplication:sourceApp];
+    return [[DeviceManager sharedManager] handleOpenURL:url];
 }
 
 - (void)needsToInstallConnectMobile {

--- a/ExampleApp/ExampleApp/DeviceManager.h
+++ b/ExampleApp/ExampleApp/DeviceManager.h
@@ -21,7 +21,7 @@
 - (instancetype)init NS_UNAVAILABLE;
 + (DeviceManager *)sharedManager;
 
-- (BOOL)handleOpenURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
+- (BOOL)handleOpenURL:(NSURL *)url;
 
 - (NSArray *)allDevices;
 

--- a/ExampleApp/ExampleApp/DeviceManager.m
+++ b/ExampleApp/ExampleApp/DeviceManager.m
@@ -60,11 +60,8 @@ NSString * const kDevicesFileName = @"devices";
 #pragma mark - METHODS
 // --------------------------------------------------------------------------------
 
-- (BOOL)handleOpenURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication {
-    if (([url.scheme isEqualToString:ReturnURLScheme] &&
-         [sourceApplication isEqualToString:IQGCMBundle]) ||
-         ([url.scheme isEqualToString:ReturnURLScheme] &&
-          [sourceApplication isEqualToString:IQGCMInternalBetaBundle])) {
+- (BOOL)handleOpenURL:(NSURL *)url {
+    if ([url.scheme isEqualToString:ReturnURLScheme]) {
         NSArray *devices = [[ConnectIQ sharedInstance] parseDeviceSelectionResponseFromURL:url];
         if (devices != nil) {
             NSLog(@"Forgetting %d known devices.", (int)self.devices.count);


### PR DESCRIPTION
A bug was found in the code that handled the device select response received from the Garmin's Connect app that provided a list of paired devices in the Connect app. This bug was introduced when iOS behavior was changed for handling the loadUrl call to not have the source app parameter set when the calling app is not developed by the same team as the CIQ app. This change was introduced since iOS13. Fixed the issue by not explicitly checking for the source app since the CIQ SDK developed by third party developers will always have the source app parameter set to `nil`. The specific option in question that changed the behavior is [UIApplicationOpenURLOptionsSourceApplicationKey](https://developer.apple.com/documentation/uikit/uiapplicationopenurloptionssourceapplicationkey?language=objc)