### PR TITLE
Update the sample to use the latest release of the CIQ Companion app SDK version 1.6.0

### DIFF
--- a/ExampleApp/ExampleApp.xcodeproj/project.pbxproj
+++ b/ExampleApp/ExampleApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -66,6 +66,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		95121AC72CCA97E000DA53EC /* ExampleApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ExampleApp.entitlements; sourceTree = "<group>"; };
 		D6054E271A64792F0029113F /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D6054E281A64792F0029113F /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D60D04A8199E546C00870EDC /* ExampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -216,6 +217,7 @@
 		D60D04B1199E546C00870EDC /* ExampleApp */ = {
 			isa = PBXGroup;
 			children = (
+				95121AC72CCA97E000DA53EC /* ExampleApp.entitlements */,
 				D60D04BA199E546C00870EDC /* AppDelegate.h */,
 				D60D04BB199E546C00870EDC /* AppDelegate.m */,
 				D65B41A919F98B4800D9E655 /* Constants.h */,
@@ -361,9 +363,6 @@
 				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Garmin;
 				TargetAttributes = {
-					D60D04A7199E546C00870EDC = {
-						DevelopmentTeam = 72ES32VZUA;
-					};
 					D60D04C8199E546D00870EDC = {
 						TestTargetID = D60D04A7199E546C00870EDC;
 					};
@@ -661,8 +660,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ExampleApp/ExampleApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/..",
@@ -676,7 +677,7 @@
 					"@executable_path/Frameworks",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.garmin.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.garmin.connectiqsdk.ExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;
@@ -687,8 +688,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = ExampleApp/ExampleApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/..",
@@ -702,7 +705,7 @@
 					"@executable_path/Frameworks",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.garmin.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.garmin.connectiqsdk.ExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;

--- a/ExampleApp/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ExampleApp/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "8546cec043655f015797511747e9dcac32fc6a266541bb73e85a63ae4956b656",
   "pins" : [
     {
       "identity" : "connectiq-companion-app-sdk-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/garmin/connectiq-companion-app-sdk-ios",
       "state" : {
-        "revision" : "d61f5b7ddb93c20a2ee2dfc67aea91fe21b66da1",
-        "version" : "1.5.2"
+        "revision" : "3312f9f50e3103e54c2c9b09b823f40a16e0c6cb",
+        "version" : "1.6.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/ExampleApp/ExampleApp/AppDelegate.m
+++ b/ExampleApp/ExampleApp/AppDelegate.m
@@ -22,7 +22,10 @@
     // Mobile is not installed, pass an instance of IQUIOverrideDelegate to this
     // method(such as self in this example). You can then bypass the alert dialog
     // or provide your own.
-    [[ConnectIQ sharedInstance] initializeWithUrlScheme:ReturnURLScheme uiOverrideDelegate:nil];
+    // Using URL Scheme
+    //[[ConnectIQ sharedInstance] initializeWithUrlScheme:ReturnURLScheme uiOverrideDelegate:nil];
+    // Using Universal links
+    [[ConnectIQ sharedInstance] initializeWithUniversalLinks:ReturnURLHost uiOverrideDelegate:nil];
     [[DeviceManager sharedManager] restoreDevicesFromFileSystem];
 
     // Override point for customization after application launch.
@@ -57,10 +60,19 @@
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(nonnull NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+    // Handle Garmin Connect app attempting to launch this companion app using URL scheme
     NSString* sourceApp = options[UIApplicationOpenURLOptionsSourceApplicationKey];
     NSLog(@"Received URL from '%@': %@", sourceApp, url);
 
     return [[DeviceManager sharedManager] handleOpenURL:url];
+}
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+    // Handle Garmin Connect app attempting to launch this companion app using universal link
+    if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
+        return [[DeviceManager sharedManager] handleOpenURL:userActivity.webpageURL];
+    }
+    return NO;
 }
 
 - (void)needsToInstallConnectMobile {

--- a/ExampleApp/ExampleApp/AppMessageViewController.m
+++ b/ExampleApp/ExampleApp/AppMessageViewController.m
@@ -194,7 +194,7 @@ static const int kMaxLogMessages = 200;
         LogMessage(@"%02.2f%% - %u/%u", percent, sentBytes, totalBytes);
     } completion:^(IQSendMessageResult result) {
         LogMessage(@"Send message finished with result %@", NSStringFromSendMessageResult(result));
-    }];
+    } isTransient:(false)];
 }
 
 - (void)logMessage:(NSString *)message {

--- a/ExampleApp/ExampleApp/Constants.h
+++ b/ExampleApp/ExampleApp/Constants.h
@@ -8,3 +8,4 @@
 #import <Foundation/Foundation.h>
 
 extern NSString * const ReturnURLScheme;
+extern NSString * const ReturnURLHost;

--- a/ExampleApp/ExampleApp/Constants.m
+++ b/ExampleApp/ExampleApp/Constants.m
@@ -8,3 +8,4 @@
 #import "Constants.h"
 
 NSString * const ReturnURLScheme = @"exapp-123456";
+NSString * const ReturnURLHost = @"connect.garmin.com/devices-list";

--- a/ExampleApp/ExampleApp/DeviceManager.m
+++ b/ExampleApp/ExampleApp/DeviceManager.m
@@ -61,7 +61,7 @@ NSString * const kDevicesFileName = @"devices";
 // --------------------------------------------------------------------------------
 
 - (BOOL)handleOpenURL:(NSURL *)url {
-    if ([url.scheme isEqualToString:ReturnURLScheme]) {
+    if ([url.scheme isEqualToString:ReturnURLScheme] || [url.scheme isEqualToString:@"https"]) {
         NSArray *devices = [[ConnectIQ sharedInstance] parseDeviceSelectionResponseFromURL:url];
         if (devices != nil) {
             NSLog(@"Forgetting %d known devices.", (int)self.devices.count);

--- a/ExampleApp/ExampleApp/ExampleApp.entitlements
+++ b/ExampleApp/ExampleApp/ExampleApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:connect.garmin.com</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Updated to use the latest release of the SDK which includes changes to support Universal Links to launch the companion app when fetching paired devices from the Garmin Connect app. Companion app now can send transient messages using the sendMessage() API.